### PR TITLE
Run 'fail' test on Windows too

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,7 @@ const AggregateError = require('aggregate-error');
 
 function win(input, opts) {
 	return taskkill(input, {
-		force: opts.force,
-		// Don't kill ourselves
-		filter: `PID ne ${process.pid}`
+		force: opts.force
 	});
 }
 

--- a/test.js
+++ b/test.js
@@ -35,14 +35,14 @@ if (process.platform === 'win32') {
 		await delay(noopProcessExitDelay);
 		t.false(await processExists(pid));
 	});
-
-	test('fail', async t => {
-		try {
-			await m(['123456', '654321']);
-			t.fail();
-		} catch (err) {
-			t.regex(err.message, /123456/);
-			t.regex(err.message, /654321/);
-		}
-	});
 }
+
+test('fail', async t => {
+	try {
+		await m(['123456', '654321']);
+		t.fail();
+	} catch (err) {
+		t.regex(err.message, /123456/);
+		t.regex(err.message, /654321/);
+	}
+});

--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ if (process.platform === 'win32') {
 		const title = 'notepad.exe';
 		const pid = childProcess.spawn(title).pid;
 
-		await m(title);
+		await m(title, {force: true});
 
 		t.false(await processExists(pid));
 	});

--- a/test.js
+++ b/test.js
@@ -54,6 +54,7 @@ test.serial('don\'t kill self', async t => {
 
 	await m(process.pid);
 
+	await delay(noopProcessExitDelay);
 	t.true(await processExists(pid));
 	Object.defineProperty(process, 'pid', {value: originalFkillPid});
 });

--- a/test.js
+++ b/test.js
@@ -46,3 +46,14 @@ test('fail', async t => {
 		t.regex(err.message, /654321/);
 	}
 });
+
+test.serial('don\'t kill self', async t => {
+	const originalFkillPid = process.pid;
+	const pid = await noopProcess();
+	Object.defineProperty(process, 'pid', {value: pid});
+
+	await m(process.pid);
+
+	t.true(await processExists(pid));
+	Object.defineProperty(process, 'pid', {value: originalFkillPid});
+});


### PR DESCRIPTION
Moves the 'fail' test from non-windows only to running on all systems.

`taskkill` already does throw when not finding a process to kill. However, we were adding a filter not to kill ourselves. The filter for some reason feels that it doesn't have to kill anything to be successful 🙁.

We currently filter on our pid twice. Maybe I'm missing something obvious, after all, I also missed the fact we're filtering out our pid twice. It looks to me like there is no reason.

* [x] Filter out our pid once, using JS, not `taskkill` filters.
* [x] Add a test to filter our pid (if possible).

---
fixes #16 