### PR TITLE
Add a delay before checking if process exists, in the test

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "ava": "*",
+    "delay": "^2.0.0",
     "noop-process": "^3.0.0",
     "process-exists": "^2.0.0",
     "xo": "*"

--- a/test.js
+++ b/test.js
@@ -6,10 +6,14 @@ import processExists from 'process-exists';
 import delay from 'delay';
 import m from './';
 
+// Delay we use for processExists check.
+// Without the delay, the check occasianally comes faster than the noop process can exit.
+const noopExitDelay = 10;
+
 test('pid', async t => {
 	const pid = await noopProcess();
 	await m(pid, {force: true});
-	await delay(10);
+	await delay(noopExitDelay);
 	t.false(await processExists(pid));
 });
 
@@ -29,7 +33,7 @@ if (process.platform === 'win32') {
 
 		await m(title);
 
-		await delay(10);
+		await delay(noopExitDelay);
 		t.false(await processExists(pid));
 	});
 

--- a/test.js
+++ b/test.js
@@ -3,11 +3,13 @@ import childProcess from 'child_process';
 import test from 'ava';
 import noopProcess from 'noop-process';
 import processExists from 'process-exists';
+import delay from 'delay';
 import m from './';
 
 test('pid', async t => {
 	const pid = await noopProcess();
 	await m(pid, {force: true});
+	await delay(10);
 	t.false(await processExists(pid));
 });
 
@@ -27,6 +29,7 @@ if (process.platform === 'win32') {
 
 		await m(title);
 
+		await delay(10);
 		t.false(await processExists(pid));
 	});
 

--- a/test.js
+++ b/test.js
@@ -6,14 +6,13 @@ import processExists from 'process-exists';
 import delay from 'delay';
 import m from './';
 
-// Delay we use for processExists check.
-// Without the delay, the check occasianally comes faster than the noop process can exit.
-const noopExitDelay = 10;
+// Ensure the noop process has time to exit
+const noopProcessExitDelay = 10;
 
 test('pid', async t => {
 	const pid = await noopProcess();
 	await m(pid, {force: true});
-	await delay(noopExitDelay);
+	await delay(noopProcessExitDelay);
 	t.false(await processExists(pid));
 });
 
@@ -33,7 +32,7 @@ if (process.platform === 'win32') {
 
 		await m(title);
 
-		await delay(noopExitDelay);
+		await delay(noopProcessExitDelay);
 		t.false(await processExists(pid));
 	});
 


### PR DESCRIPTION
Trying to fix #10. Need to run CI builds for this.

Only looking at builds where neither `pid` or `title` failed, since neither has seen much change.
I skipped about 7 0ms delay Travis builds. About half of those are failing.

CI|Delay|passing builds|tries
--|------|--------------|----
Windows 10|0ms|10|10
macOS|0ms|9|10
Travis|0ms|8|15
Travis|100ms|9|9
Travis|10ms|4|4
AppVeyor|100ms|0|1
AppVeyor|200ms|5|6
AppVeyor|1000ms|1|1
AppVeyor|600ms|1|1
AppVeyor|0ms|3|3

(Waiting for builds... 🕐 . Too short to work on other things, long enough to get bored)
(I'm worried my table might not be BCNF compliant 🤔 🙈 )
(No, it's perfectly BCNF actually. Candidate key would be CI + Delay. All good 🤓 )