### PR TITLE
Accept tree option on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const AggregateError = require('aggregate-error');
 function win(input, opts) {
 	return taskkill(input, {
 		force: opts.force,
-		tree: opts.tree
+		tree: typeof opts.tree !== 'undefined' ? opts.tree : true
 	});
 }
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const AggregateError = require('aggregate-error');
 
 function win(input, opts) {
 	return taskkill(input, {
-		force: opts.force
+		force: opts.force,
+		tree: opts.tree
 	});
 }
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const AggregateError = require('aggregate-error');
 function win(input, opts) {
 	return taskkill(input, {
 		force: opts.force,
-		tree: typeof opts.tree !== 'undefined' ? opts.tree : true
+		tree: typeof opts.tree === 'undefined' ? true : opts.tree
 	});
 }
 

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ Force kill the process.
 Type: `boolean`<br>
 Default: `true`
 
-Terminate all child processes along with the parent process (*only on Windows*).
+Kill all child processes along with the parent process. *(Windows only)*
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,13 @@ Default: `false`
 
 Force kill the process.
 
+##### tree
+
+Type: `boolean`<br>
+Default: `true`
+
+Terminate all child processes along with the parent process (*only on Windows*).
+
 
 ## Related
 


### PR DESCRIPTION
We are having a hard time to use this package on Windows because we need to pass the `tree` option to `taskkill`.

This PR solves it.

Reference: https://github.com/diegohaz/arc/issues/248#issuecomment-302150978