### PR TITLE
Add `silent` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ module.exports = async (inputs, options = {}) => {
 		inputs.map(input => handleKill(input))
 	);
 
-	if (errors.length > 0) {
+	if (errors.length > 0 && !options.silent) {
 		throw new AggregateError(errors);
 	}
 };

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,13 @@ Ignore capitalization when killing a process.
 
 Note that the case is always ignored on Windows.
 
+##### silent
+
+Type: `boolean`<br>
+Default: `false`
+
+Suppress all error messages. For example: `Process doesn't exist`.
+
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -91,3 +91,8 @@ test('kill from port', async t => {
 test('error when process is not found', async t => {
 	await t.throwsAsync(fkill(['notFoundProcess']), /Killing process notFoundProcess failed: Process doesn't exist/);
 });
+
+test('suppress errors when silent', async t => {
+	await t.notThrowsAsync(fkill(['123456', '654321'], {silent: true}));
+	await t.notThrowsAsync(fkill(['notFoundProcess'], {silent: true}));
+});


### PR DESCRIPTION
Pretty simple PR, I tried to suppress only the `not found` error, but that caused problems on Windows, so I chose to implement a `silent all` option instead.

Resolves #26