### PR TITLE
Don't kill `fkill` when killing `node`

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,11 +97,11 @@ const fkill = async (inputs, options = {}) => {
 
 			if (input === 'node') {
 				const processes = await psList();
-				processes.forEach(async ps => {
+				await Promise.all(processes.map(async ps => {
 					if (ps.name === 'node' && ps.pid !== process.pid) {
 						await kill(ps.pid, options);
 					}
-				});
+				}));
 				return;
 			}
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const execa = require('execa');
 const AggregateError = require('aggregate-error');
 const pidFromPort = require('pid-from-port');
 const processExists = require('process-exists');
+const psList = require('ps-list');
 
 const missingBinaryError = async (command, arguments_) => {
 	try {
@@ -91,6 +92,16 @@ const fkill = async (inputs, options = {}) => {
 			input = await parseInput(input);
 
 			if (input === process.pid) {
+				return;
+			}
+
+			if (input === 'node') {
+				const processes = await psList();
+				processes.forEach(async ps => {
+					if (ps.name === 'node' && ps.pid !== process.pid) {
+						await kill(ps.pid, options);
+					}
+				});
 				return;
 			}
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
 		"execa": "^1.0.0",
 		"pid-from-port": "^1.1.3",
 		"process-exists": "^3.1.0",
-		"taskkill": "^3.0.0"
+		"taskkill": "^3.0.0",
+		"ps-list": "^6.3.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",

--- a/test.js
+++ b/test.js
@@ -73,7 +73,7 @@ test.serial('don\'t kill self', async t => {
 	Object.defineProperty(process, 'pid', {value: originalFkillPid});
 });
 
-test.serial('don\'t kill self when kill node', async t => {
+test.serial('don\'t kill `fkill` when killing `node`', async t => {
 	const originalFkillPid = process.pid;
 	await fkill('node');
 

--- a/test.js
+++ b/test.js
@@ -75,14 +75,9 @@ test.serial('don\'t kill self', async t => {
 
 test.serial('don\'t kill self when kill node', async t => {
 	const originalFkillPid = process.pid;
-	const pid = await noopProcess();
-	Object.defineProperty(process, 'pid', {value: pid});
-
 	await fkill('node');
 
-	await delay(noopProcessKilled(t, pid));
-	t.true(await processExists(pid));
-	Object.defineProperty(process, 'pid', {value: originalFkillPid});
+	t.true(await processExists(originalFkillPid));
 });
 
 test('ignore ignore-case for pid', async t => {

--- a/test.js
+++ b/test.js
@@ -73,6 +73,18 @@ test.serial('don\'t kill self', async t => {
 	Object.defineProperty(process, 'pid', {value: originalFkillPid});
 });
 
+test.serial('don\'t kill self when kill node', async t => {
+	const originalFkillPid = process.pid;
+	const pid = await noopProcess();
+	Object.defineProperty(process, 'pid', {value: pid});
+
+	await fkill('node');
+
+	await delay(noopProcessKilled(t, pid));
+	t.true(await processExists(pid));
+	Object.defineProperty(process, 'pid', {value: originalFkillPid});
+});
+
 test('ignore ignore-case for pid', async t => {
 	const pid = await noopProcess();
 	await fkill(pid, {force: true, ignoreCase: true});


### PR DESCRIPTION
fix #19