### PR TITLE
Make extension optional in Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,23 @@ const AggregateError = require('aggregate-error');
 const pidFromPort = require('pid-from-port');
 const processExists = require('process-exists');
 
-const winKill = (input, options) => {
-	const newInput = typeof input === 'string' ? input.concat('*') : input;
-	return taskkill(newInput, {
+const killWithTask = (input, options) => {
+	return taskkill(input, {
 		force: options.force,
 		tree: typeof options.tree === 'undefined' ? true : options.tree
 	});
+};
+
+const winKill = async (input, options) => {
+	try {
+		const firstTry = input;
+		return await killWithTask(firstTry, options);
+	} catch (error) {
+		if (typeof input === 'string') {
+			const secondTry = input.concat('.exe');
+			return killWithTask(secondTry, options);
+		}
+	}
 };
 
 const macOSKill = (input, options) => {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ const pidFromPort = require('pid-from-port');
 const processExists = require('process-exists');
 
 const winKill = (input, options) => {
-	return taskkill(input, {
+	const newInput = typeof input === 'string' ? input.concat('*') : input;
+	return taskkill(newInput, {
 		force: options.force,
 		tree: typeof options.tree === 'undefined' ? true : options.tree
 	});

--- a/test.js
+++ b/test.js
@@ -29,6 +29,15 @@ if (process.platform === 'win32') {
 		t.false(await processExists(pid));
 	});
 
+	test.serial('win default without extension', async t => {
+		const title = 'notepad.exe';
+		const {pid} = childProcess.spawn(title);
+
+		await fkill('notepad', {force: true});
+
+		t.false(await processExists(pid));
+	});
+
 	test.serial('win default ignore case', async t => {
 		const title = 'notepad.exe';
 		const {pid} = childProcess.spawn(title);


### PR DESCRIPTION
Added '*' character to filter program's name, removing mandatory program extension.

Fixes #1