### PR TITLE
Add `forceTimeout` option

### DIFF
--- a/fixture-ignore-sigterm.js
+++ b/fixture-ignore-sigterm.js
@@ -1,0 +1,2 @@
+process.on('SIGTERM', () => {});
+setInterval(() => {}, 10000);

--- a/fixture-ignore-sigterm.js
+++ b/fixture-ignore-sigterm.js
@@ -1,2 +1,3 @@
 process.on('SIGTERM', () => {});
 setInterval(() => {}, 10000);
+

--- a/fixture-ignore-sigterm.js
+++ b/fixture-ignore-sigterm.js
@@ -1,3 +1,2 @@
 process.on('SIGTERM', () => {});
 setInterval(() => {}, 10000);
-

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ declare namespace fkill {
 
 		/**
 		If not force killing, wait up to `forceTimeout` number of milliseconds for process(es) to exit, then force kill the ones which didn't.
+
 		@default undefined
 		*/
 		readonly forceTimeout?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,12 @@ declare namespace fkill {
 		readonly force?: boolean;
 
 		/**
+		If not force killing, wait up to `forceTimeout` number of milliseconds for process(es) to exit, then force kill the ones which didn't.
+		@default undefined
+		*/
+		readonly forceTimeout?: number;
+
+		/**
 		Kill all child processes along with the parent process. _(Windows only)_
 
 		@default true

--- a/index.js
+++ b/index.js
@@ -26,11 +26,17 @@ const missingBinaryError = async (command, arguments_) => {
 	}
 };
 
-const windowsKill = (input, options) => {
-	return taskkill(input, {
-		force: options.force,
-		tree: typeof options.tree === 'undefined' ? true : options.tree
-	});
+const windowsKill = async (input, options) => {
+	try {
+		return await taskkill(input, {
+			force: options.force,
+			tree: typeof options.tree === 'undefined' ? true : options.tree
+		});
+	} catch (error) {
+		if (!options.force && error.exitCode !== 255) { // Indicates process filters SIGTERM
+			throw error;
+		}
+	}
 };
 
 const macosKill = (input, options) => {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,3 +7,4 @@ expectType<Promise<void>>(fkill([1337, 'Safari', ':8080']));
 expectType<Promise<void>>(fkill(1337, {force: true}));
 expectType<Promise<void>>(fkill(1337, {tree: false}));
 expectType<Promise<void>>(fkill(1337, {ignoreCase: true}));
+expectType<Promise<void>>(fkill(1337, {forceTimeout: 10000}));

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,13 @@ Default: `false`
 
 Force kill the process.
 
+##### forceTimeout
+
+Type: `number`\
+Default: `undefined`
+
+If not force killing, wait up to `forceTimeout` number of milliseconds for process(es) to exit, then force kill the ones which didn't.
+
 ##### tree
 
 Type: `boolean`\

--- a/test.js
+++ b/test.js
@@ -104,3 +104,22 @@ test('suppress errors when silent', async t => {
 	await t.notThrowsAsync(fkill(['123456', '654321'], {silent: true}));
 	await t.notThrowsAsync(fkill(['notFoundProcess'], {silent: true}));
 });
+
+test('force works properly for process ignoring SIGTERM', async t => {
+	const {pid} = childProcess.spawn(process.execPath, ['fixture-ignore-sigterm.js']);
+	await fkill(pid, {});
+	await delay(100);
+	t.true(await processExists(pid));
+	await fkill(pid, {force: true});
+	await noopProcessKilled(t, pid);
+});
+
+test('forceTimeout works properly for process ignoring SIGTERM', async t => {
+	const {pid} = childProcess.spawn(process.execPath, ['fixture-ignore-sigterm.js']);
+	const promise = fkill(pid, {forceTimeout: 100});
+	t.true(await processExists(pid));
+	await delay(50);
+	t.true(await processExists(pid));
+	await promise;
+	await noopProcessKilled(t, pid);
+});


### PR DESCRIPTION
Add `forceTimeout` option.

If not force killing, wait up to `forceTimeout` number of milliseconds for process(es) to exit, then force kill the ones which didn't.
Is not used by default(no breaking change).

Unify windows behavior, if process filters SIGTERM, don't throw error(that is what is done for other platforms).

Required for https://github.com/sindresorhus/fkill-cli/pull/70