### PR TITLE
Fix `force` on macOS when killing by name

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,11 @@ const macosKill = (input, options) => {
 	const arguments_ = [input];
 
 	if (options.force) {
-		arguments_.unshift('-9');
+		if (killByName) {
+			arguments_.unshift('-KILL');
+		} else {
+			arguments_.unshift('-9');
+		}
 	}
 
 	if (killByName && options.ignoreCase) {


### PR DESCRIPTION
`pkill` does not have a `-9` option, but it does support `-KILL`.

Resolves #40