### PR TITLE
Make .EXE extension optional in windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const windowsKill = async (input, options) => {
 		if (typeof input === 'string') {
 			return killWithTaskkill(input.concat('.exe'), options);
 		}
-		
+
 		throw error;
 	}
 };

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const windowsKill = async (input, options) => {
 	try {
 		return await killWithTaskkill(input, options);
 	} catch (error) {
-		if (typeof input === 'string') {
+		if (typeof input === 'string' && !input.endsWith('.exe')) {
 			return killWithTaskkill(input.concat('.exe'), options);
 		}
 

--- a/index.js
+++ b/index.js
@@ -21,11 +21,22 @@ const missingBinaryError = async (command, arguments_) => {
 	}
 };
 
-const windowsKill = (input, options) => {
+const killWithTaskkill = (input, options) => {
 	return taskkill(input, {
 		force: options.force,
 		tree: typeof options.tree === 'undefined' ? true : options.tree
 	});
+};
+
+const windowsKill = async (input, options) => {
+	try {
+		return await killWithTaskkill(input, options);
+	} catch (error) {
+		if (typeof input === 'string') {
+			return killWithTaskkill(input.concat('.exe'), options);
+		}
+		throw error;
+	}
 };
 
 const macosKill = (input, options) => {

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ const windowsKill = async (input, options) => {
 		if (typeof input === 'string') {
 			return killWithTaskkill(input.concat('.exe'), options);
 		}
+		
 		throw error;
 	}
 };

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ const fkill = require('fkill');
 
 if (process.platform === 'win32') {
 	fkill('notepad');
-	console.log('Killed notepad.exe');
+	console.log('Killed notepad.exe process');
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ $ npm install fkill
 
 ## Usage
 
+### Common
 ```js
 const fkill = require('fkill');
 
@@ -32,6 +33,20 @@ fkill('Safari');
 fkill(':8080');
 
 fkill([1337, 'Safari', ':8080']);
+```
+
+### OS Specific
+
+#### Windows
+
+When a string is provided, the method will try to kill a process by name. If it doesn't succeed, it will try to append `.exe`.
+```js
+const fkill = require('fkill');
+
+if (process.platform === 'win32') {
+	fkill('notepad');
+	console.log('Killed notepad.exe');
+}
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,6 @@ $ npm install fkill
 
 ## Usage
 
-### Common
 ```js
 const fkill = require('fkill');
 
@@ -35,20 +34,6 @@ fkill(':8080');
 fkill([1337, 'Safari', ':8080']);
 ```
 
-### OS Specific
-
-#### Windows
-
-When a string is provided, the method will try to kill a process by name. If it doesn't succeed, it will try to append `.exe`.
-```js
-const fkill = require('fkill');
-
-if (process.platform === 'win32') {
-	fkill('notepad');
-	console.log('Killed notepad.exe process');
-}
-```
-
 ## API
 
 ### fkill(input, options?)
@@ -59,7 +44,7 @@ Returns a promise that resolves when the process is killed.
 
 Type: `number | string | Array<number | string>`
 
-One or more process IDs/names/ports to kill.
+One or more process IDs/names/ports to kill. **NOTE:** You can optionally choose to provide binaries extensions on windows.
 
 To kill a port, prefix it with a colon. For example: `:8080`.
 

--- a/readme.md
+++ b/readme.md
@@ -86,3 +86,4 @@ Suppress all error messages. For example: `Process doesn't exist`.
 
 - [fkill-cli](https://github.com/sindresorhus/fkill-cli) - CLI for this module
 - [alfred-fkill](https://github.com/SamVerschueren/alfred-fkill) - Alfred workflow for this module
+ 

--- a/test.js
+++ b/test.js
@@ -29,6 +29,31 @@ if (process.platform === 'win32') {
 		t.false(await processExists(pid));
 	});
 
+	test.serial('window - supports extension-less process name', async t => {
+		const title = 'notepad.exe';
+		const {pid} = childProcess.spawn(title);
+
+		await fkill('notepad', {force: true});
+
+		t.false(await processExists(pid));
+	});
+
+	test.serial('windows - for killing based on integer instead of string', async t => {
+		const pid = await noopProcess();
+		await fkill(pid, {force: true});
+		await noopProcessKilled(t, pid);
+	});
+
+	test.serial('windows - expect an error if process integer does not exist', async t => {
+		const pid = await noopProcess();
+		await fkill(pid, {force: true});
+		await noopProcessKilled(t, pid);
+		
+		const error = await t.throwsAsync(fkill(pid, {force: true}));
+		const regex = new RegExp(pid);
+		t.regex(error.message, regex);
+	});
+	
 	test.serial('win default ignore case', async t => {
 		const title = 'notepad.exe';
 		const {pid} = childProcess.spawn(title);

--- a/test.js
+++ b/test.js
@@ -48,12 +48,12 @@ if (process.platform === 'win32') {
 		const pid = await noopProcess();
 		await fkill(pid, {force: true});
 		await noopProcessKilled(t, pid);
-		
+
 		const error = await t.throwsAsync(fkill(pid, {force: true}));
 		const regex = new RegExp(pid);
 		t.regex(error.message, regex);
 	});
-	
+
 	test.serial('win default ignore case', async t => {
 		const title = 'notepad.exe';
 		const {pid} = childProcess.spawn(title);


### PR DESCRIPTION
Hello. Continuing from https://github.com/sindresorhus/fkill/pull/32 ... It's merger dropped development for a year and sindre closed it ... I am willing to split bounty, and finish what ever needs to be touched up in order to find a solution for https://github.com/sindresorhus/fkill/issues/1 ...

Not sure if regression tests are proper, also I hope error catching will serve the requested changes justice.

Thanks. Please let me know if I missed anything. Might also want to make a loop for **%PATHEXT%**?

Closes #1


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1: Make extension optional on Windows?](https://issuehunt.io/repos/37784838/issues/1)
---
</details>
<!-- /Issuehunt content-->