### PR TITLE
Add `forceAfterTimeout` option

### DIFF
--- a/fixture-ignore-sigterm.js
+++ b/fixture-ignore-sigterm.js
@@ -1,0 +1,2 @@
+process.on('SIGTERM', () => {});
+setInterval(() => {}, 10000);

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,13 @@ declare namespace fkill {
 		readonly force?: boolean;
 
 		/**
+		If not force killing, wait up to `forceAfterTimeout` number of milliseconds for process(es) to exit, then force kill the ones which didn't.
+
+		@default undefined
+		*/
+		readonly forceAfterTimeout?: number;
+
+		/**
 		Kill all child processes along with the parent process. _(Windows only)_
 
 		@default true

--- a/index.js
+++ b/index.js
@@ -7,6 +7,16 @@ const pidFromPort = require('pid-from-port');
 const processExists = require('process-exists');
 const psList = require('ps-list');
 
+// If we check too soon we're unlikely to see process killed so we essentially wait 3*ALIVE_CHECK_MIN_INTERVAL before second check while producing unnecessary load
+// Primitive tests show that for process which just die on kill on a system without much load we can usually see process die in 5 ms.
+// Checking once a second creates low enough load to not bother increasing maximum interval further, 1280 as first x to satisfy 2^^x * ALIVE_CHECK_MIN_INTERVAL > 1000.
+const ALIVE_CHECK_MIN_INTERVAL = 5;
+const ALIVE_CHECK_MAX_INTERVAL = 1280;
+
+const TASKKILL_EXIT_CODE_FOR_PROCESS_FILTERING_SIGTERM = 255;
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
 const missingBinaryError = async (command, arguments_) => {
 	try {
 		return await execa(command, arguments_);
@@ -21,11 +31,17 @@ const missingBinaryError = async (command, arguments_) => {
 	}
 };
 
-const windowsKill = (input, options) => {
-	return taskkill(input, {
-		force: options.force,
-		tree: typeof options.tree === 'undefined' ? true : options.tree
-	});
+const windowsKill = async (input, options) => {
+	try {
+		return await taskkill(input, {
+			force: options.force,
+			tree: typeof options.tree === 'undefined' ? true : options.tree
+		});
+	} catch (error) {
+		if (!options.force && error.exitCode !== TASKKILL_EXIT_CODE_FOR_PROCESS_FILTERING_SIGTERM) {
+			throw error;
+		}
+	}
 };
 
 const macosKill = (input, options) => {
@@ -84,6 +100,26 @@ const parseInput = async input => {
 	return input;
 };
 
+const killWithLimits = async (input, options) => {
+	input = await parseInput(input);
+
+	if (input === process.pid) {
+		return;
+	}
+
+	if (input === 'node') {
+		const processes = await psList();
+		await Promise.all(processes.map(async ps => {
+			if (ps.name === 'node' && ps.pid !== process.pid) {
+				await kill(ps.pid, options);
+			}
+		}));
+		return;
+	}
+
+	await kill(input, options);
+};
+
 const fkill = async (inputs, options = {}) => {
 	inputs = arrify(inputs);
 
@@ -93,23 +129,7 @@ const fkill = async (inputs, options = {}) => {
 
 	const handleKill = async input => {
 		try {
-			input = await parseInput(input);
-
-			if (input === process.pid) {
-				return;
-			}
-
-			if (input === 'node') {
-				const processes = await psList();
-				await Promise.all(processes.map(async ps => {
-					if (ps.name === 'node' && ps.pid !== process.pid) {
-						await kill(ps.pid, options);
-					}
-				}));
-				return;
-			}
-
-			await kill(input, options);
+			await killWithLimits(input, options);
 		} catch (error) {
 			if (!exists.get(input)) {
 				errors.push(`Killing process ${input} failed: Process doesn't exist`);
@@ -126,6 +146,38 @@ const fkill = async (inputs, options = {}) => {
 
 	if (errors.length > 0 && !options.silent) {
 		throw new AggregateError(errors);
+	}
+
+	if (options.forceAfterTimeout !== undefined && !options.force) {
+		const endTime = Date.now() + options.forceAfterTimeout;
+		let interval = ALIVE_CHECK_MIN_INTERVAL;
+		if (interval > options.forceAfterTimeout) {
+			interval = options.forceAfterTimeout;
+		}
+
+		let alive = inputs;
+
+		do {
+			await delay(interval); // eslint-disable-line no-await-in-loop
+
+			alive = await processExists.filterExists(alive); // eslint-disable-line no-await-in-loop
+
+			interval *= 2;
+			if (interval > ALIVE_CHECK_MAX_INTERVAL) {
+				interval = ALIVE_CHECK_MAX_INTERVAL;
+			}
+		} while (Date.now() < endTime && alive.length > 0);
+
+		if (alive.length > 0) {
+			await Promise.all(alive.map(async input => {
+				try {
+					await killWithLimits(input, {...options, force: true});
+				} catch (_) {
+					// It's hard to filter does-not-exist kind of errors, so we ignore all of them here.
+					// All meaningful errors should have been thrown before this operation takes place.
+				}
+			}));
+		}
 	}
 };
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,3 +7,4 @@ expectType<Promise<void>>(fkill([1337, 'Safari', ':8080']));
 expectType<Promise<void>>(fkill(1337, {force: true}));
 expectType<Promise<void>>(fkill(1337, {tree: false}));
 expectType<Promise<void>>(fkill(1337, {ignoreCase: true}));
+expectType<Promise<void>>(fkill(1337, {forceAfterTimeout: 10000}));

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,13 @@ Default: `false`
 
 Force kill the process.
 
+##### forceAfterTimeout
+
+Type: `number`\
+Default: `undefined`
+
+If not force killing, wait up to `forceAfterTimeout` number of milliseconds for process(es) to exit, then force kill the ones which didn't.
+
 ##### tree
 
 Type: `boolean`\

--- a/test.js
+++ b/test.js
@@ -97,3 +97,22 @@ test('suppress errors when silent', async t => {
 	await t.notThrowsAsync(fkill(['123456', '654321'], {silent: true}));
 	await t.notThrowsAsync(fkill(['notFoundProcess'], {silent: true}));
 });
+
+test('force works properly for process ignoring SIGTERM', async t => {
+	const {pid} = childProcess.spawn(process.execPath, ['fixture-ignore-sigterm.js']);
+	await fkill(pid, {});
+	await delay(100);
+	t.true(await processExists(pid));
+	await fkill(pid, {force: true});
+	await noopProcessKilled(t, pid);
+});
+
+test('forceAfterTimeout works properly for process ignoring SIGTERM', async t => {
+	const {pid} = childProcess.spawn(process.execPath, ['fixture-ignore-sigterm.js']);
+	const promise = fkill(pid, {forceAfterTimeout: 100});
+	t.true(await processExists(pid));
+	await delay(50);
+	t.true(await processExists(pid));
+	await promise;
+	await noopProcessKilled(t, pid);
+});

--- a/test.js
+++ b/test.js
@@ -73,13 +73,6 @@ test.serial('don\'t kill self', async t => {
 	Object.defineProperty(process, 'pid', {value: originalFkillPid});
 });
 
-test.serial('don\'t kill `fkill` when killing `node`', async t => {
-	const originalFkillPid = process.pid;
-	await fkill('node');
-
-	t.true(await processExists(originalFkillPid));
-});
-
 test('ignore ignore-case for pid', async t => {
 	const pid = await noopProcess();
 	await fkill(pid, {force: true, ignoreCase: true});


### PR DESCRIPTION
Add `forceAfterTimeout` option.

If not force killing, wait up to `forceAfterTimeout` number of milliseconds for process(es) to exit, then force kill the ones which didn't.
Is not used by default(no breaking change).

Unify windows behavior, if process filters SIGTERM, don't throw error(that is what is done for other platforms).

Required for sindresorhus/fkill-cli#70 followup.
Fixes #44 