### PR TITLE
replace pid-from-port with find-pid-from-port

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const arrify = require('arrify');
 const taskkill = require('taskkill');
 const execa = require('execa');
 const AggregateError = require('aggregate-error');
-const pidFromPort = require('pid-from-port');
+const findPidFromPort = require('find-pid-from-port');
 const processExists = require('process-exists');
 const psList = require('ps-list');
 
@@ -78,7 +78,7 @@ const kill = (() => {
 
 const parseInput = async input => {
 	if (typeof input === 'string' && input[0] === ':') {
-		return pidFromPort(parseInt(input.slice(1), 10));
+		return findPidFromPort(parseInt(input.slice(1), 10));
 	}
 
 	return input;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"aggregate-error": "^3.0.0",
 		"arrify": "^2.0.1",
 		"execa": "^4.0.0",
-		"pid-from-port": "^1.1.3",
+		"find-pid-from-port": "^0.1.0",
 		"process-exists": "^4.0.0",
 		"ps-list": "^7.0.0",
 		"taskkill": "^3.0.0"


### PR DESCRIPTION
pid-from-port is not maintained for 3 years. It uses an old execa version which has security vulnerabilities.

The code of find-pid-from-port looks like a copy but it uses native exec.