### PR TITLE
Add `forceAfterTimeout` option

### DIFF
--- a/fixture-ignore-sigterm.js
+++ b/fixture-ignore-sigterm.js
@@ -1,0 +1,2 @@
+process.on('SIGTERM', () => {});
+setInterval(() => {}, 10000);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,14 @@
 declare namespace fkill {
 	interface Options {
 		/**
-		Force kill the process.
+		Force kill the processes.
 
 		@default false
 		*/
 		readonly force?: boolean;
 
 		/**
-		If not force killing, wait up to `forceAfterTimeout` number of milliseconds for process(es) to exit, then force kill the ones which didn't.
+		Force kill processes that did not exit within the given number of milliseconds.
 
 		@default undefined
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,13 @@ declare namespace fkill {
 		readonly force?: boolean;
 
 		/**
+		If not force killing, wait up to `forceAfterTimeout` number of milliseconds for process(es) to exit, then force kill the ones which didn't.
+
+		@default undefined
+		*/
+		readonly forceAfterTimeout?: number;
+
+		/**
 		Kill all child processes along with the parent process. _(Windows only)_
 
 		@default true

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ const pidPort = require('pid-port');
 const processExists = require('process-exists');
 const psList = require('ps-list');
 
-// If we check too soon we're unlikely to see process killed so we essentially wait 3*ALIVE_CHECK_MIN_INTERVAL before second check while producing unnecessary load
-// Primitive tests show that for process which just die on kill on a system without much load we can usually see process die in 5 ms.
+// If we check too soon, we're unlikely to see process killed so we essentially wait 3*ALIVE_CHECK_MIN_INTERVAL before the second check while producing unnecessary load.
+// Primitive tests show that for a process which just dies on kill on a system without much load, we can usually see the process die in 5 ms.
 // Checking once a second creates low enough load to not bother increasing maximum interval further, 1280 as first x to satisfy 2^^x * ALIVE_CHECK_MIN_INTERVAL > 1000.
 const ALIVE_CHECK_MIN_INTERVAL = 5;
 const ALIVE_CHECK_MAX_INTERVAL = 1280;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,3 +7,4 @@ expectType<Promise<void>>(fkill([1337, 'Safari', ':8080']));
 expectType<Promise<void>>(fkill(1337, {force: true}));
 expectType<Promise<void>>(fkill(1337, {tree: false}));
 expectType<Promise<void>>(fkill(1337, {ignoreCase: true}));
+expectType<Promise<void>>(fkill(1337, {forceAfterTimeout: 10000}));

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ fkill([1337, 'Safari', ':8080']);
 
 ### fkill(input, options?)
 
-Returns a promise that resolves when the process is killed.
+Returns a promise that resolves when the processes are killed.
 
 #### input
 
@@ -55,14 +55,14 @@ Type: `object`
 Type: `boolean`\
 Default: `false`
 
-Force kill the process.
+Force kill the processes.
 
 ##### forceAfterTimeout
 
 Type: `number`\
 Default: `undefined`
 
-Wait up to `forceAfterTimeout` number of milliseconds for processes to exit, then force kill the ones which didn't.
+Force kill processes that did not exit within the given number of milliseconds.
 
 ##### tree
 

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,13 @@ Default: `false`
 
 Force kill the process.
 
+##### forceAfterTimeout
+
+Type: `number`\
+Default: `undefined`
+
+Wait up to `forceAfterTimeout` number of milliseconds for processes to exit, then force kill the ones which didn't.
+
 ##### tree
 
 Type: `boolean`\

--- a/test.js
+++ b/test.js
@@ -1,4 +1,3 @@
-/* eslint-disable ava/no-identical-title */
 import childProcess from 'child_process';
 import test from 'ava';
 import noopProcess from 'noop-process';
@@ -6,6 +5,10 @@ import processExists from 'process-exists';
 import delay from 'delay';
 import getPort from 'get-port';
 import fkill from '.';
+
+const testRequiringNoopProcessToSetTitleProperly = () => {
+	return (process.versions.node.split('.')[0] === '12') ? test.skip : test;
+};
 
 async function noopProcessKilled(t, pid) {
 	// Ensure the noop process has time to exit.
@@ -38,7 +41,7 @@ if (process.platform === 'win32') {
 		t.false(await processExists(pid));
 	});
 } else {
-	test('title', async t => {
+	testRequiringNoopProcessToSetTitleProperly()('title', async t => {
 		const title = 'fkill-test';
 		const pid = await noopProcess({title});
 
@@ -47,7 +50,7 @@ if (process.platform === 'win32') {
 		await noopProcessKilled(t, pid);
 	});
 
-	test('ignore case', async t => {
+	testRequiringNoopProcessToSetTitleProperly()('ignore case', async t => {
 		const pid = await noopProcess({title: 'Capitalized'});
 		await fkill('capitalized', {ignoreCase: true});
 

--- a/test.js
+++ b/test.js
@@ -73,13 +73,6 @@ test.serial('don\'t kill self', async t => {
 	Object.defineProperty(process, 'pid', {value: originalFkillPid});
 });
 
-test.serial('don\'t kill `fkill` when killing `node`', async t => {
-	const originalFkillPid = process.pid;
-	await fkill('node');
-
-	t.true(await processExists(originalFkillPid));
-});
-
 test('ignore ignore-case for pid', async t => {
 	const pid = await noopProcess();
 	await fkill(pid, {force: true, ignoreCase: true});
@@ -103,4 +96,23 @@ test('error when process is not found', async t => {
 test('suppress errors when silent', async t => {
 	await t.notThrowsAsync(fkill(['123456', '654321'], {silent: true}));
 	await t.notThrowsAsync(fkill(['notFoundProcess'], {silent: true}));
+});
+
+test('force works properly for process ignoring SIGTERM', async t => {
+	const {pid} = childProcess.spawn(process.execPath, ['fixture-ignore-sigterm.js']);
+	await fkill(pid, {});
+	await delay(100);
+	t.true(await processExists(pid));
+	await fkill(pid, {force: true});
+	await noopProcessKilled(t, pid);
+});
+
+test('forceAfterTimeout works properly for process ignoring SIGTERM', async t => {
+	const {pid} = childProcess.spawn(process.execPath, ['fixture-ignore-sigterm.js']);
+	const promise = fkill(pid, {forceAfterTimeout: 100});
+	t.true(await processExists(pid));
+	await delay(50);
+	t.true(await processExists(pid));
+	await promise;
+	await noopProcessKilled(t, pid);
 });


### PR DESCRIPTION
Add forceAfterTimeout option.

If not force killing, wait up to forceAfterTimeout number of milliseconds for process(es) to exit, then force kill the ones which didn't.
Is not used by default(no breaking change).

Unify windows behavior, if process filters SIGTERM, don't throw error(that is what is done for other platforms).

Added skips for title-related tests on Node v12 as it doesn't seem the issue with setting `process.title` will ever be resolved(no moves on that front, v12 is going out of maintenance in a year).

Required for sindresorhus/fkill-cli#80.
Fixes #44