### PR TITLE
Fix not getting error when force killing non-existent process

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,9 +40,11 @@ const windowsKill = async (input, options) => {
 			tree: typeof options.tree === 'undefined' ? true : options.tree
 		});
 	} catch (error) {
-		if (!options.force && error.exitCode !== TASKKILL_EXIT_CODE_FOR_PROCESS_FILTERING_SIGTERM) {
-			throw error;
+		if (error.exitCode === TASKKILL_EXIT_CODE_FOR_PROCESS_FILTERING_SIGTERM && !options.force) {
+			return;
 		}
+
+		throw error;
 	}
 };
 

--- a/test.js
+++ b/test.js
@@ -96,6 +96,13 @@ test('error when process is not found', async t => {
 	);
 });
 
+test('error when process is not found (force: true)', async t => {
+	await t.throwsAsync(
+		fkill(['notFoundProcess'], {force: true}),
+		{message: /Killing process notFoundProcess failed: Process doesn't exist/}
+	);
+});
+
 test('suppress errors when silent', async t => {
 	await t.notThrowsAsync(fkill(['123456', '654321'], {silent: true}));
 	await t.notThrowsAsync(fkill(['notFoundProcess'], {silent: true}));


### PR DESCRIPTION
Added a test for force killing non-existent process, fixed not getting error when force killing non-existent process.

Fixes an issue introduced in https://github.com/sindresorhus/fkill/pull/54.