### PR TITLE
Ensure force killing by name works on macOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ const macosKill = (input, options) => {
 		arguments_.unshift('-x');
 	}
 
+	// Must be last.
 	if (options.force) {
 		if (killByName) {
 			arguments_.unshift('-KILL');

--- a/index.js
+++ b/index.js
@@ -52,20 +52,20 @@ const macosKill = (input, options) => {
 	const command = killByName ? 'pkill' : 'kill';
 	const arguments_ = [input];
 
-	if (options.force) {
-		if (killByName) {
-			arguments_.unshift('-KILL');
-		} else {
-			arguments_.unshift('-9');
-		}
-	}
-
 	if (killByName && options.ignoreCase) {
 		arguments_.unshift('-i');
 	}
 
 	if (killByName) {
 		arguments_.unshift('-x');
+	}
+
+	if (options.force) {
+		if (killByName) {
+			arguments_.unshift('-KILL');
+		} else {
+			arguments_.unshift('-9');
+		}
 	}
 
 	return missingBinaryError(command, arguments_);

--- a/test.js
+++ b/test.js
@@ -68,6 +68,13 @@ if (process.platform === 'win32') {
 		// Cleanup
 		await fkill(title);
 	});
+
+	testRequiringNoopProcessToSetTitleProperly()('force', async t => {
+		const pid = await noopProcess({title: 'force'});
+		await fkill('force', {force: true});
+
+		await noopProcessKilled(t, pid);
+	});
 }
 
 test('fail', async t => {


### PR DESCRIPTION
Killing a process using `pkill -x -KILL <name>` throws an error with `pkill: illegal option -- K`. Setting `-KILL` as the first flag fixes the it.